### PR TITLE
Fix devops tests

### DIFF
--- a/.github/workflows/devopstest.yml
+++ b/.github/workflows/devopstest.yml
@@ -33,7 +33,7 @@ jobs:
       if: always()
       run: |
         go run ./cmd/agent/main.go &
-        timeout 10 nc -l 8080
+        timeout 10 echo "" | nc -l 8080
 
     - name: "[Code increment #2] Start server (and listen 8080)"
       if: always()

--- a/.github/workflows/devopstest.yml
+++ b/.github/workflows/devopstest.yml
@@ -69,7 +69,7 @@ jobs:
     - name: "[Code increment #3] Monitoring data"
       if: always()
       run: |
-        devopstest -test.v -test.run=^TestMonitoringData$ ./...
+        timeout 60 devopstest -test.v -test.run=^TestMonitoringData$ ./...
 
     # - name: "[Code increment #4] Check JSON API handler"
     #   if: always()

--- a/.github/workflows/devopstest.yml
+++ b/.github/workflows/devopstest.yml
@@ -27,18 +27,18 @@ jobs:
     - name: "[Code increment #1] Start agent (and work at least 10s)"
       if: always()
       run: |
-        sh -c 'eval "timeout 10 go run ./cmd/agent/..."; if [ $? -eq 124 ]; then exit 0; else exit 100; fi'
+        sh -c 'eval "timeout 10 go run ./cmd/agent/main.go"; if [ $? -eq 124 ]; then exit 0; else exit 100; fi'
 
     - name: "[Code increment #2] Start agent (can receive data via 8080)"
       if: always()
       run: |
-        go run ./cmd/agent/... &
+        go run ./cmd/agent/main.go &
         timeout 10 nc -l 8080
 
     - name: "[Code increment #2] Start server (and listen 8080)"
       if: always()
       run: |
-        go run ./cmd/server/... &
+        go run ./cmd/server/main.go &
         timeout 10 sh -c 'until lsof -i:8080; do sleep 1s; done'
 
     - name: "[Code increment #2] Post"
@@ -119,6 +119,6 @@ jobs:
     #   run: |
     #     devopstest -test.v -test.run=^TestSetGetMetricsWithRestartBefore$ ./...
     #     killall server
-    #     go run ./cmd/server/... &
+    #     go run ./cmd/server/main.go &
     #     timeout 10 sh -c 'until lsof -i:8080; do sleep 1s; done'
     #     devopstest -test.v -test.run=^TestSetGetMetricsWithRestartAfter$ ./...

--- a/.github/workflows/devopstest.yml
+++ b/.github/workflows/devopstest.yml
@@ -19,18 +19,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
 
-    - name: Download devopstest binary
-      uses: robinraju/release-downloader@v1
-      with:
-        repository: Yandex-Practicum/go-autotests-bin
-        latest: true
-        fileName: devopstest
-        out-file-path: .tools
-
-    - name: Setup autotest binary
+    - name: Download and setup autotest binary
       run: |
-        chmod -R +x $GITHUB_WORKSPACE/.tools/devopstest
-        mv $GITHUB_WORKSPACE/.tools/devopstest /usr/local/bin/devopstest
+        wget https://github.com/Yandex-Practicum/go-autotests-bin/raw/main/.tools/devopstest -O /usr/local/bin/devopstest
+        chmod +x /usr/local/bin/devopstest
 
     - name: "[Code increment #1] Start agent (and work at least 10s)"
       if: always()


### PR DESCRIPTION
- Исправлена проблема, когда не загружается релиз devopstest  через robinraju/release-downloader
- При запуске агента или сервера, запуск происходит не через вилдкард ... а указывается main.go (исправляет проблемы запуска, когда в папках есть еще go файлы, помимо main.go)
- Добавлен пустой ответ для netcat, для избежания ожидания второго запроса от агента. Исправляет ситуацию, когда интервал пуша данных в агенте больше 5 секунд
- Добавлен таймаут для теста [Code increment #3] Monitoring data - так как при ошибке он никогда не заканчивается